### PR TITLE
Fix memleak

### DIFF
--- a/lib/stream_split.ex
+++ b/lib/stream_split.ex
@@ -21,6 +21,8 @@ defmodule StreamSplit do
         {:lists.reverse(list), []}
       {:suspended, {_, list}, cont} ->
         {:lists.reverse(list), continuation_to_stream(cont)}
+      {:halted, {_, []}} ->
+        {[], []}
     end
   end
   def take_and_drop(enum, 0) do

--- a/lib/stream_split.ex
+++ b/lib/stream_split.ex
@@ -1,4 +1,7 @@
 defmodule StreamSplit do
+  @enforce_keys [:continuation, :stream]
+  defstruct @enforce_keys
+
   @doc """
   This function is a combination of `Enum.take/2` and `Enum.drop/2` returning
   first `n` dropped elements and the rest of the enum as a stream.
@@ -14,19 +17,31 @@ defmodule StreamSplit do
       iex> Enum.take(tail, 7)
       [2, 3, 1, 2, 3, 1, 2]
   """
-  @spec take_and_drop(Enumerable.t, pos_integer) :: {List.t, Enumerable.t}
+  @spec take_and_drop(Enumerable.t(), pos_integer) :: {List.t(), Enumerable.t()}
   def take_and_drop(enum, n) when n > 0 do
-    case Enumerable.reduce(enum, {:cont, {n, []}}, &reducer_helper/2) do
+    case apply_reduce(enum, n) do
       {:done, {_, list}} ->
         {:lists.reverse(list), []}
+
       {:suspended, {_, list}, cont} ->
-        {:lists.reverse(list), continuation_to_stream(cont)}
+        stream_split = %__MODULE__{continuation: cont, stream: continuation_to_stream(cont)}
+        {:lists.reverse(list), stream_split}
+
       {:halted, {_, []}} ->
         {[], []}
     end
   end
+
   def take_and_drop(enum, 0) do
     {[], enum}
+  end
+
+  defp apply_reduce(%__MODULE__{continuation: cont}, n) do
+    cont.({:cont, {n, []}})
+  end
+
+  defp apply_reduce(enum, n) do
+    Enumerable.reduce(enum, {:cont, {n, []}}, &reducer_helper/2)
   end
 
   defp reducer_helper(item, :tail) do
@@ -42,22 +57,24 @@ defmodule StreamSplit do
   end
 
   defp continuation_to_stream(cont) do
-    wrapped =
-      fn {_, _, acc_cont} -> 
-        case acc_cont.({:cont, :tail}) do
-          acc = {:suspended, item, _cont} ->
-            {[item], acc}
-          {:done, acc} ->
-            {:halt, acc}
-        end
+    wrapped = fn {_, _, acc_cont} ->
+      case acc_cont.({:cont, :tail}) do
+        acc = {:suspended, item, _cont} ->
+          {[item], acc}
+
+        {:done, acc} ->
+          {:halt, acc}
       end
-    cleanup =
-      fn
-        {:suspended, _, acc_cont} ->
-          acc_cont.({:halt, nil})
-        _ ->
-          nil
-      end
+    end
+
+    cleanup = fn
+      {:suspended, _, acc_cont} ->
+        acc_cont.({:halt, nil})
+
+      _ ->
+        nil
+    end
+
     Stream.resource(fn -> {:suspended, nil, cont} end, wrapped, cleanup)
   end
 
@@ -79,9 +96,9 @@ defmodule StreamSplit do
       iex> Enum.take(new_enum, 7)
       [1, 2, 3, 1, 2, 3, 1]
   """
-  @spec peek(Enumerable.t, pos_integer) :: {List.t, Enumerable.t}
+  @spec peek(Enumerable.t(), pos_integer) :: {List.t(), Enumerable.t()}
   def peek(enum, n) when n >= 0 do
-    {h, t} = take_and_drop enum, n
+    {h, t} = take_and_drop(enum, n)
     {h, Stream.concat(h, t)}
   end
 
@@ -98,9 +115,21 @@ defmodule StreamSplit do
       iex> Enum.take(tail, 7)
       [2, 3, 1, 2, 3, 1, 2]
   """
-  @spec pop(Enumerable.t) :: {any, Enumerable.t}
+  @spec pop(Enumerable.t()) :: {any, Enumerable.t()}
   def pop(enum) do
-    {[h], rest} = take_and_drop enum, 1
+    {[h], rest} = take_and_drop(enum, 1)
     {h, rest}
+  end
+end
+
+defimpl Enumerable, for: StreamSplit do
+  def count(_stream_split), do: {:error, __MODULE__}
+
+  def member?(_stream_split, _value), do: {:error, __MODULE__}
+
+  def slice(_stream_split), do: {:error, __MODULE__}
+
+  def reduce(%StreamSplit{stream: stream}, acc, fun) do
+    Enumerable.reduce(stream, acc, fun)
   end
 end

--- a/test/stream_split_test.exs
+++ b/test/stream_split_test.exs
@@ -2,7 +2,10 @@ defmodule StreamSplitTest do
   use ExUnit.Case
   doctest StreamSplit, import: true
 
-  # test "the truth" do
-    # assert 1 + 1 == 2
-    # end
+  test "empty stream" do
+    stream = Stream.resource(fn -> nil end, fn s -> {:halt, s} end, fn _ -> nil end)
+    assert Enum.to_list(stream) == []
+    {elements, []} = StreamSplit.take_and_drop(stream, 1)
+    assert elements == []
+  end
 end

--- a/test/stream_split_test.exs
+++ b/test/stream_split_test.exs
@@ -8,4 +8,27 @@ defmodule StreamSplitTest do
     {elements, []} = StreamSplit.take_and_drop(stream, 1)
     assert elements == []
   end
+
+  test "multiple pops" do
+    {1, stream} = Stream.cycle([1, 2, 3]) |> StreamSplit.pop()
+    {2, stream} = stream |> StreamSplit.pop()
+    {3, stream} = stream |> StreamSplit.pop()
+    {1, _stream} = stream |> StreamSplit.pop()
+  end
+
+  test "does not leak" do
+    {_, stream} = Stream.cycle([1, 2, 3]) |> StreamSplit.pop()
+
+    stream_after_some_pops =
+      1..1000
+      |> Enum.reduce(stream, fn _, stream_acc ->
+        {_, stream_acc} = StreamSplit.pop(stream_acc)
+        stream_acc
+      end)
+
+    init_size = byte_size(:erlang.term_to_binary(stream))
+    final_size = byte_size(:erlang.term_to_binary(stream_after_some_pops))
+
+    assert_in_delta final_size / init_size, 1, 0.1
+  end
 end


### PR DESCRIPTION
 I found this lib after some research on splitting streams, and it's been fun to see that I contributed to it over two years ago and forgot about it :D So now I had a closer look on it and noticed that when doing multiple `StreamSplit.pop`s or `take_and_drop`s, sizes of returned streams are constantly growing:

```elixir
    {_, stream} = Stream.cycle([1, 2, 3]) |> StreamSplit.pop()
    stream_after_some_pops = 1..1000 |> Enum.reduce(stream, fn _, stream_acc ->
      {_, stream_acc} = StreamSplit.pop(stream_acc)
      stream_acc
    end)
    byte_size(:erlang.term_to_binary(stream)) # -> 905
    byte_size(:erlang.term_to_binary(stream_after_some_pops)) # -> 694903
```

Also, the duration of subsequent calls was getting longer and longer. That happened probably due to wrapping the stream on each call to `StreamSplit.take_and_drop`. This PR fixes this issue and also contains some fixes from the fork by @magnetised